### PR TITLE
Fix Pyrotheum falling regardless of config

### DIFF
--- a/src/main/java/cofh/thermalfoundation/fluid/BlockFluidPyrotheum.java
+++ b/src/main/java/cofh/thermalfoundation/fluid/BlockFluidPyrotheum.java
@@ -124,7 +124,7 @@ public class BlockFluidPyrotheum extends BlockFluidInteractive {
 		if (effect) {
 			checkForInteraction(world, x, y, z);
 		}
-		if (world.getBlockMetadata(x, y, z) == 0) {
+		if (enableSourceFall && world.getBlockMetadata(x, y, z) == 0) {
 			Block block = world.getBlock(x, y + densityDir, z);
 			int bMeta = world.getBlockMetadata(x, y + densityDir, z);
 


### PR DESCRIPTION
Currently there is an option in the config named `Fluid.Pyrotheum.B:Fall`. This setting is read during Thermal Foundation's initialization, and is stored by the Pyrotheum fluid class. However, during _block ticking_, the block is made to fall **irrespective of the setting**.

This adds the missing check back into the Pyrotheum fluid, to make the config work just like the Cryotheum fluid.
