### PR TITLE
ItemTome.java

### DIFF
--- a/src/main/java/cofh/thermalfoundation/item/ItemTome.java
+++ b/src/main/java/cofh/thermalfoundation/item/ItemTome.java
@@ -45,6 +45,7 @@ public class ItemTome extends ItemMulti implements IInitializer, IInventoryConta
 
 		setUnlocalizedName("tome");
 		setCreativeTab(ThermalFoundation.tabCommon);
+		setMaxStackSize(1);
 	}
 
 	protected boolean isEmpowered(ItemStack stack) {


### PR DESCRIPTION
Fixing the bug that the Forge Lexicon stacks to 64.
![2017-07-31_11 43 42](https://user-images.githubusercontent.com/26633478/28774505-a75b3380-75e5-11e7-9ce7-4900a58b3d1b.png)
