### PR TITLE
Don't try to create worldgen files if CoFH World not present

### DIFF
--- a/src/main/java/cofh/thermalfoundation/ThermalFoundation.java
+++ b/src/main/java/cofh/thermalfoundation/ThermalFoundation.java
@@ -1,7 +1,6 @@
 package cofh.thermalfoundation;
 
 import cofh.CoFHCore;
-import cofh.cofhworld.CoFHWorld;
 import cofh.core.init.CoreEnchantments;
 import cofh.core.init.CorePotions;
 import cofh.core.init.CoreProps;
@@ -38,7 +37,7 @@ public class ThermalFoundation {
 	public static final String VERSION_GROUP = "required-after:" + MOD_ID + "@[" + VERSION + "," + VERSION_MAX + ");";
 	public static final String UPDATE_URL = "https://raw.github.com/cofh/version/master/" + MOD_ID + "_update.json";
 
-	public static final String DEPENDENCIES = CoFHCore.VERSION_GROUP + CoFHWorld.VERSION_GROUP + "before:enderio;" + "before:immersiveengineering";
+	public static final String DEPENDENCIES = CoFHCore.VERSION_GROUP + "before:enderio;" + "before:immersiveengineering";
 	public static final String MOD_GUI_FACTORY = "cofh.thermalfoundation.gui.GuiConfigTFFactory";
 
 	@Instance (MOD_ID)

--- a/src/main/java/cofh/thermalfoundation/init/TFProps.java
+++ b/src/main/java/cofh/thermalfoundation/init/TFProps.java
@@ -14,6 +14,7 @@ import cofh.thermalfoundation.item.tome.ItemTomeLexicon;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.io.FileUtils;
@@ -379,6 +380,10 @@ public class TFProps {
 		boolean generateDefaultFiles = ThermalFoundation.CONFIG.getConfiguration().getBoolean("GenerateDefaultFiles", category, true, comment);
 
 		if (!generateDefaultFiles) {
+			return;
+		}
+		if(!net.minecraftforge.fml.common.Loader.isModLoaded("cofhworld")) {
+			ThermalFoundation.LOG.error("CoFH World is not enabled, no worldgen files will be generated!");
 			return;
 		}
 		worldGenFile = new File(CoreProps.configDir, "/cofh/world/" + worldGenOre);


### PR DESCRIPTION
Not strictly necessary but stops the log being cluttered by the stacktrace. Might make it harder for people to realise that they haven't installed CoFH World though. 